### PR TITLE
Integrate theme switch button to landing page

### DIFF
--- a/src/components/ThemeButton/ToggleDarkModeButton.test.tsx
+++ b/src/components/ThemeButton/ToggleDarkModeButton.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ToggleDarkModeButton from './ToggleDarkModeButton';
 
+//TODO(PR#123): refactor this function to async
+
 test('Test theme button toggle', () => {
   render(<ToggleDarkModeButton />);
   const buttonEl = screen.getByText(/🌙/i);


### PR DESCRIPTION
### What this PR does:
Adds Light/Dark theme button switcher to the landing page.
Adds global state of Light/Dark theme which changes the text and background color using Context API.

### Screenshots:
![demo screenshot](https://i.imgur.com/H2UtNB4.png)
![demo screenshot](https://i.imgur.com/ZPFBrbY.png)

### Any information needed to test this feature:
git clone this repo
run 'npm i'
run 'npm start'
Your browser should open 'http://localhost:3000/peatix_takehome'
Click the toggle button below the Temperature Toggle

